### PR TITLE
Apply linter when syntax is set to HTML Extended

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -17,7 +17,7 @@ class Polylint(NodeLinter):
 
     """Provides an interface to polylint."""
 
-    syntax = ('html')
+    syntax = ('html', 'html-extended')
     cmd = ('polylint', '--no-recursion', '-i')
     executable = None
     version_args = '--version'


### PR DESCRIPTION
The [HTML Extended](https://github.com/orizens/html-extended) syntax has better support for highlighting HTML correctly when Web Components are used. Using that syntax however disables this linter. This fixes that.
